### PR TITLE
Add Union type hints to `full_grid_input_partial`

### DIFF
--- a/dense_mouse_grid/full_mouse_grid.py
+++ b/dense_mouse_grid/full_mouse_grid.py
@@ -894,7 +894,7 @@ class GridActions:
         mg.adjust_field_size(amount)
 
 
-    def full_grid_input_partial(letter: str):
+    def full_grid_input_partial(letter: Union[str,int]):
         """Input one letter to highlight a row or column"""
         mg.add_partial_input(str(letter))
 


### PR DESCRIPTION
This method is called either with a number or a string, and without the `int` type hint there is an error in the logs.

```
2022-04-14 16:26:24 ERROR TalonScript TypeError in: /Users/rickymcmillen/.talon/user/dense-mouse-grid/dense_mouse_grid/full_mouse_grid_open.talon:19
2022-04-14 16:26:24 ERROR Line 20: user.full_grid_input_partial(letter: str)
2022-04-14 16:26:24 ERROR Line 20:   parameter 1 (letter) expects type <class 'str'>, got <class 'int'>
```

This did not appear to effect the functionality at all.

(I have no idea how to python, I learnt this from a quick google)